### PR TITLE
Fixing spacing for volumes in the deployments.yaml

### DIFF
--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.volumes }}
-    volumes:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
This attribute should be in-line with `containers` but it was a tab short, which was causing errors when trying to mess with configmaps.