### PR TITLE
Adding support for k8s 1.22

### DIFF
--- a/charts/kpow/templates/ingress.yaml
+++ b/charts/kpow/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -16,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -34,8 +35,10 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/kpow/templates/ingress.yaml
+++ b/charts/kpow/templates/ingress.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: extensions/v1beta1
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: networking.k8s.io/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -34,11 +36,17 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+            {{- else -}}
             backend:
               service:
                 name: {{ $fullName }}
                 port: 
                   number: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -42,6 +42,7 @@ ingress:
   annotations: {}
   hosts: []
   tls: []
+  ingressClassName: ""
 
 # We recommend running kPow w/ Guaranteed QOS class and 1 CPU / 2G Memory.
 # Small resource sets (e.g. 1 cluster, 1 schema registry) can likely run with 0.5 CPU / 1G Memory or less.


### PR DESCRIPTION
We are seeing some issues with this chart after we updated to 1.22, specifically around `apiVersion: networking.k8s.io/v1beta1`.