### PR TITLE
Fixing ingress template

### DIFF
--- a/charts/kpow/templates/ingress.yaml
+++ b/charts/kpow/templates/ingress.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: extensions/v1beta1
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: networking.k8s.io/v1
@@ -30,23 +30,31 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-            {{- else -}}
+          {{- end }}
+    {{- end }}
+    {{- else -}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
             backend:
               service:
                 name: {{ $fullName }}
                 port: 
                   number: {{ $svcPort }}
-            {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
The prior change I made had a flaw that I didn't catch in testing.  If the `if` statement is down by the backend config, it will throw the following error. 
```Error: template: kpow/charts/kpow/templates/ingress.yaml:39:56: executing "kpow/charts/kpow/templates/ingress.yaml" at <.Capabilities.KubeVersion.GitVersion>: can't evaluate field Capabilities in type interface {}```
Moving it up above `host` solved it.  
My original testing didn't catch it due to a misconfiguration in my values files I was passing in 😞