### PR TITLE
Add support for labels

### DIFF
--- a/charts/kpow/templates/_helpers.tpl
+++ b/charts/kpow/templates/_helpers.tpl
@@ -52,6 +52,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Provided labels
+*/}}
+{{- define "kpow.providedLabels" -}}
+{{- if .Values.labels }}
+{{- toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "kpow.serviceAccountName" -}}

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kpow.labels" . | nindent 4 }}
+    {{- include "kpow.providedLabels" . | nindent 4 }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -20,6 +21,7 @@ spec:
     {{- end }}
       labels:
         {{- include "kpow.selectorLabels" . | nindent 8 }}
+        {{- include "kpow.providedLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -70,3 +70,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+labels: {}


### PR DESCRIPTION
This pull request proposes to add support for providing labels via a `labels` key in values file.

Example:
```
labels:
  label-one: value-one
```

These labels will be applied in the Deployment resource under the keys:

`metadata.labels` and `spec.template.metadata.labels`