### PR TITLE
Add service monitor for simple configuration of prometheus metrics

### DIFF
--- a/charts/kpow/templates/_helpers.tpl
+++ b/charts/kpow/templates/_helpers.tpl
@@ -72,11 +72,11 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Verify if all metrics should be exported
+If all metrics should be exported
 */}}
 {{- define "kpow.monitor.exportAllMetrics" -}}
-{{- with .Values.serviceMonitor }}
-{{- if and (eq (len .topics) 0) (eq (len .clusters) 0) (eq (len .schemas) 0) }}
+{{- with .Values.serviceMonitor.metrics }}
+{{- if and (eq (len .clusters) 0) (eq (len .schemas) 0) }}
 {{- print true }}
 {{- else }}
 {{- print false }}
@@ -85,10 +85,10 @@ Verify if all metrics should be exported
 {{- end }}
 
 {{/*
-Verify if all offset and cluster metrics should be exported
+If all offsets should be exported
 */}}
-{{- define "kpow.monitor.exportAllOffsetAndClusterMetrics" -}}
-{{- with .Values.serviceMonitor }}
+{{- define "kpow.monitor.exportAllOffsets" -}}
+{{- with .Values.serviceMonitor.offsets }}
 {{- if and (eq (len .topics) 0) (eq (len .clusters) 0) }}
 {{- print true }}
 {{- else }}

--- a/charts/kpow/templates/_helpers.tpl
+++ b/charts/kpow/templates/_helpers.tpl
@@ -70,3 +70,39 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Verify if all metrics should be exported
+*/}}
+{{- define "kpow.monitor.exportAllMetrics" -}}
+{{- with .Values.serviceMonitor }}
+{{- if and (eq (len .topics) 0) (eq (len .clusters) 0) (eq (len .schemas) 0) }}
+{{- true }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Verify if all offset and cluster metrics should be exported
+*/}}
+{{- define "kpow.monitor.exportAllOffsetAndClusterMetrics" -}}
+{{- with .Values.serviceMonitor }}
+{{- if and (eq (len .topics) 0) (eq (len .clusters) 0) }}
+{{- true }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate service monitor endpoint
+*/}}
+{{- define "kpow.monitor.endpoint" -}}
+{{- $endpoint := $1 }}
+- interval: {{ .Values.serviceMonitor.interval | default "15s" }}
+  port: {{ .Values.service.port }}
+  path: {{ $endpoint }}
+{{- end }}

--- a/charts/kpow/templates/_helpers.tpl
+++ b/charts/kpow/templates/_helpers.tpl
@@ -77,9 +77,9 @@ Verify if all metrics should be exported
 {{- define "kpow.monitor.exportAllMetrics" -}}
 {{- with .Values.serviceMonitor }}
 {{- if and (eq (len .topics) 0) (eq (len .clusters) 0) (eq (len .schemas) 0) }}
-{{- true }}
+{{- print true }}
 {{- else }}
-{{- false }}
+{{- print false }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -90,9 +90,9 @@ Verify if all offset and cluster metrics should be exported
 {{- define "kpow.monitor.exportAllOffsetAndClusterMetrics" -}}
 {{- with .Values.serviceMonitor }}
 {{- if and (eq (len .topics) 0) (eq (len .clusters) 0) }}
-{{- true }}
+{{- print true }}
 {{- else }}
-{{- false }}
+{{- print false }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -101,8 +101,9 @@ Verify if all offset and cluster metrics should be exported
 Generate service monitor endpoint
 */}}
 {{- define "kpow.monitor.endpoint" -}}
-{{- $endpoint := $1 }}
-- interval: {{ .Values.serviceMonitor.interval | default "15s" }}
-  port: {{ .Values.service.port }}
+{{- $endpoint := index . 0 }}
+{{- $values := index . 1 }}
+- interval: {{ $values.serviceMonitor.interval | default "15s" }}
+  port: {{ $values.service.port }}
   path: {{ $endpoint }}
 {{- end }}

--- a/charts/kpow/templates/servicemonitor.yaml
+++ b/charts/kpow/templates/servicemonitor.yaml
@@ -21,6 +21,8 @@ spec:
       {{- end }}
     {{- end }}
     {{- if eq (include "kpow.monitor.exportAllOffsets" .) "true" }}
+      {{- include "kpow.monitor.endpoint" (list "/offsets/v1" .Values) | nindent 4 }}
+    {{- else }}
       {{- range .Values.serviceMonitor.offsets.topics }}
         {{- $topicEndpoint := printf "/offsets/v1/topic/%s" . }}
         {{- include "kpow.monitor.endpoint" (list $topicEndpoint $.Values) | nindent 4 }}

--- a/charts/kpow/templates/servicemonitor.yaml
+++ b/charts/kpow/templates/servicemonitor.yaml
@@ -3,31 +3,39 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels: {{ .Values.serviceMonitor.labels | toYaml }}
+  labels:
+    {{ .Values.serviceMonitor.labels | toYaml | nindent 4 }}
   name: {{ include "kpow.fullname" . }}
 spec:
   endpoints:
-    {{- if (include "kpow.monitor.exportAllMetrics" .)}}
-      {{- include "kpow.monitor.endpoint" "/metrics/v1" }}
-    {{- else if (include "kpow.monitor.exportAllOffsetAndClusterMetrics" .) }}
+    {{- if eq (include "kpow.monitor.exportAllMetrics" .) "true" }}
+      {{- include "kpow.monitor.endpoint" (list "/metrics/v1" .Values) | nindent 4 }}
+    {{- else if eq (include "kpow.monitor.exportAllOffsetAndClusterMetrics" .) "true" }}
       {{- range .Values.serviceMonitor.schemas}}
-        {{- include "kpow.monitor.endpoint" (printf "/metrics/v1/schema/%s" .) }}
+        {{- $schemaEndpoint := printf "/metrics/v1/schema/%s" . }}
+        {{- include "kpow.monitor.endpoint" (list $schemaEndpoint $.Values) | nindent 4 }}
       {{- end }}
-      {{- include "kpow.monitor.endpoint" "/offsets/v1" }}
-      {{- include "kpow.monitor.endpoint" "/group-offsets/v1" }}
+      {{- include "kpow.monitor.endpoint" (list "/offsets/v1" .Values) | nindent 4 }}
+      {{- include "kpow.monitor.endpoint" (list "/group-offsets/v1" .Values) | nindent 4 }}
     {{- else }}
-      {{- range .Values.serviceMonitor.schemas}}
-        {{- include "kpow.monitor.endpoint" (printf "/metrics/v1/schema/%s" .) }}
+      {{- range .Values.serviceMonitor.schemas }}
+        {{- $schemaEndpoint := printf "/metrics/v1/schema/%s" . }}
+        {{- include "kpow.monitor.endpoint" (list $schemaEndpoint $.Values) | nindent 4 }}
       {{- end }}
       {{- range .Values.serviceMonitor.topics}}
-        {{- include "kpow.monitor.endpoint" (printf "/offsets/v1/topic/%s" .) }}
+        {{- $topicEndpoint := printf "/metrics/v1/topic/%s" . }}
+        {{- include "kpow.monitor.endpoint" (list $topicEndpoint $.Values) | nindent 4 }}
       {{- end }}
       {{- range .Values.serviceMonitor.clusters}}
-        {{- include "kpow.monitor.endpoint" (printf "/metrics/v1/cluster/%s" .) }}
-        {{- include "kpow.monitor.endpoint" (printf "/offsets/v1/cluster/%s" .) }}
+        {{- $metricsClusterEndpoint := printf "/metrics/v1/cluster/%s" . }}
+        {{- $offsetClusterEndpoint := printf "/offsets/v1/cluster/%s" . }}
+        {{- include "kpow.monitor.endpoint" (list $metricsClusterEndpoint $.Values) | nindent 4 }}
+        {{- include "kpow.monitor.endpoint" (list $offsetClusterEndpoint $.Values) | nindent 4 }}
       {{- end }}
     {{- end }}
-  jobLabel: {{ .Values.serviceMonitor.jobLabel | toYaml }}
-  namespaceSelector: {{ .Values.serviceMonitor.namespaceSelector | toYaml }}
-  selector: {{ .Values.serviceMonitor.selector | toYaml }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  namespaceSelector:
+    {{- .Values.serviceMonitor.namespaceSelector | toYaml | nindent 4 }}
+  selector:
+    {{- .Values.serviceMonitor.selector | toYaml | nindent 4 }}
 {{- end }}

--- a/charts/kpow/templates/servicemonitor.yaml
+++ b/charts/kpow/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ spec:
   endpoints:
     {{- if (include "kpow.monitor.exportAllMetrics" .)}}
       {{- include "kpow.monitor.endpoint" "/metrics/v1" }}
-    {{- elif (include "kpow.monitor.exportAllOffsetAndClusterMetrics" .) }}
+    {{- else if (include "kpow.monitor.exportAllOffsetAndClusterMetrics" .) }}
       {{- range .Values.serviceMonitor.schemas}}
         {{- include "kpow.monitor.endpoint" (printf "/metrics/v1/schema/%s" .) }}
       {{- end }}

--- a/charts/kpow/templates/servicemonitor.yaml
+++ b/charts/kpow/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels: {{ .Values.serviceMonitor.labels | toYaml }}
+  name: {{ include "kpow.fullname" . }}
+spec:
+  endpoints:
+    {{- if (include "kpow.monitor.exportAllMetrics" .)}}
+      {{- include "kpow.monitor.endpoint" "/metrics/v1" }}
+    {{- elif (include "kpow.monitor.exportAllOffsetAndClusterMetrics" .) }}
+      {{- range .Values.serviceMonitor.schemas}}
+        {{- include "kpow.monitor.endpoint" (printf "/metrics/v1/schema/%s" .) }}
+      {{- end }}
+      {{- include "kpow.monitor.endpoint" "/offsets/v1" }}
+      {{- include "kpow.monitor.endpoint" "/group-offsets/v1" }}
+    {{- else }}
+      {{- range .Values.serviceMonitor.schemas}}
+        {{- include "kpow.monitor.endpoint" (printf "/metrics/v1/schema/%s" .) }}
+      {{- end }}
+      {{- range .Values.serviceMonitor.topics}}
+        {{- include "kpow.monitor.endpoint" (printf "/offsets/v1/topic/%s" .) }}
+      {{- end }}
+      {{- range .Values.serviceMonitor.clusters}}
+        {{- include "kpow.monitor.endpoint" (printf "/metrics/v1/cluster/%s" .) }}
+        {{- include "kpow.monitor.endpoint" (printf "/offsets/v1/cluster/%s" .) }}
+      {{- end }}
+    {{- end }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | toYaml }}
+  namespaceSelector: {{ .Values.serviceMonitor.namespaceSelector | toYaml }}
+  selector: {{ .Values.serviceMonitor.selector | toYaml }}
+{{- end }}

--- a/charts/kpow/templates/servicemonitor.yaml
+++ b/charts/kpow/templates/servicemonitor.yaml
@@ -10,28 +10,28 @@ spec:
   endpoints:
     {{- if eq (include "kpow.monitor.exportAllMetrics" .) "true" }}
       {{- include "kpow.monitor.endpoint" (list "/metrics/v1" .Values) | nindent 4 }}
-    {{- else if eq (include "kpow.monitor.exportAllOffsetAndClusterMetrics" .) "true" }}
-      {{- range .Values.serviceMonitor.schemas}}
-        {{- $schemaEndpoint := printf "/metrics/v1/schema/%s" . }}
-        {{- include "kpow.monitor.endpoint" (list $schemaEndpoint $.Values) | nindent 4 }}
-      {{- end }}
-      {{- include "kpow.monitor.endpoint" (list "/offsets/v1" .Values) | nindent 4 }}
-      {{- include "kpow.monitor.endpoint" (list "/group-offsets/v1" .Values) | nindent 4 }}
     {{- else }}
-      {{- range .Values.serviceMonitor.schemas }}
+      {{- range .Values.serviceMonitor.metrics.clusters }}
+        {{- $metricsClusterEndpoint := printf "/metrics/v1/cluster/%s" . }}
+        {{- include "kpow.monitor.endpoint" (list $metricsClusterEndpoint $.Values) | nindent 4 }}
+      {{- end }}
+      {{- range .Values.serviceMonitor.metrics.schemas}}
         {{- $schemaEndpoint := printf "/metrics/v1/schema/%s" . }}
         {{- include "kpow.monitor.endpoint" (list $schemaEndpoint $.Values) | nindent 4 }}
       {{- end }}
-      {{- range .Values.serviceMonitor.topics}}
-        {{- $topicEndpoint := printf "/metrics/v1/topic/%s" . }}
+    {{- end }}
+    {{- if eq (include "kpow.monitor.exportAllOffsets" .) "true" }}
+      {{- range .Values.serviceMonitor.offsets.topics }}
+        {{- $topicEndpoint := printf "/offsets/v1/topic/%s" . }}
         {{- include "kpow.monitor.endpoint" (list $topicEndpoint $.Values) | nindent 4 }}
       {{- end }}
-      {{- range .Values.serviceMonitor.clusters}}
-        {{- $metricsClusterEndpoint := printf "/metrics/v1/cluster/%s" . }}
+      {{- range .Values.serviceMonitor.offsets.clusters}}
         {{- $offsetClusterEndpoint := printf "/offsets/v1/cluster/%s" . }}
-        {{- include "kpow.monitor.endpoint" (list $metricsClusterEndpoint $.Values) | nindent 4 }}
         {{- include "kpow.monitor.endpoint" (list $offsetClusterEndpoint $.Values) | nindent 4 }}
       {{- end }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.offsets.groups }}
+      {{- include "kpow.monitor.endpoint" (list "/group-offsets/v1" .Values) | nindent 4 }}
     {{- end }}
   jobLabel: {{ .Values.serviceMonitor.jobLabel }}
   namespaceSelector:

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -74,10 +74,14 @@ affinity: {}
 labels: {}
 
 serviceMonitor:
-  enabled: false
-  schemas: []
-  topics: []
-  clusters: []
+  enabled: true
+  metrics:
+    clusters: []
+    schemas: []
+  offsets:
+    groups: false
+    topics: []
+    clusters: []
   labels: {}
   jobLabel: null
   namespaceSelector: {}

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -74,7 +74,7 @@ affinity: {}
 labels: {}
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   metrics:
     clusters: []
     schemas: []

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -72,3 +72,13 @@ tolerations: []
 affinity: {}
 
 labels: {}
+
+serviceMonitor:
+  enabled: false
+  schemas: []
+  topics: []
+  clusters: []
+  labels: {}
+  jobLabel: {}
+  namespaceSelector: {}
+  selector: {}

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -79,7 +79,7 @@ serviceMonitor:
     clusters: []
     schemas: []
   offsets:
-    groups: false
+    groups: true
     topics: []
     clusters: []
   labels: {}

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -79,6 +79,6 @@ serviceMonitor:
   topics: []
   clusters: []
   labels: {}
-  jobLabel: {}
+  jobLabel: null
   namespaceSelector: {}
   selector: {}


### PR DESCRIPTION
The idea behind this pull request is to add a serviceMonitor configuration to the helm chart so that it can be used in combination with the prometheus operator.

The configuration allows for simple provision of the correct metric and offset endpoints.

Conceptually, the split was made between metrics and offsets. The options are:
- get all metrics OR specific metrics for schemas and clusters
- get all offsets OR  specific offsets for topics and clusters
- get group offsets OR not

# Configuration examples

## All metrics + Offsets

```yaml
serviceMonitor:
  enabled: true
  metrics:
    clusters: []
    schemas: []
  offsets:
    groups: true
    topics: []
    clusters: []
``` 

Will generate:
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-kpow
spec:
  endpoints:
    - interval: 15s
       port: 3000
       path: /metrics/v1
    - interval: 15s
       port: 3000
       path: /offsets/v1
    - interval: 15s
       port: 3000
       path: /group-offsets/v1
```

## Specific Metrics

```yaml
serviceMonitor:
  enabled: true
  metrics:
    clusters: 
     - cluster-1
    schemas:
    - schema-1
  offsets:
    groups: true
    topics: []
    clusters: []
``` 

Will generate:
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-kpow
spec:
  endpoints:
    - interval: 15s
       port: 3000
       path: /metrics/v1/cluster/cluster-1   
    - interval: 15s
       port: 3000
       path: /metrics/v1/schema/schema-1
    - interval: 15s
       port: 3000
       path: /offsets/v1
    - interval: 15s
       port: 3000
       path: /group-offsets/v1
```

## Specific Offsets

```yaml
serviceMonitor:
  enabled: true
  metrics:
    clusters: []
    schemas: []
  offsets:
    groups: true
    topics: 
      - topic-1
    clusters: 
      - cluster-1
``` 

Will generate:
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-kpow
spec:
  endpoints:
    - interval: 15s
       port: 3000
       path: /metrics/v1
    - interval: 15s
       port: 3000
       path: /offsets/v1/topic/topic-1
    - interval: 15s
       port: 3000
       path: /offsets/v1/cluster/cluster-1
    - interval: 15s
       port: 3000
       path: /group-offsets/v1
```

## Without group offsets

```yaml
serviceMonitor:
  enabled: true
  metrics:
    clusters: []
    schemas: []
  offsets:
    groups: false
    topics: []
    clusters: []
``` 

Will generate:
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-kpow
spec:
  endpoints:
    - interval: 15s
       port: 3000
       path: /metrics/v1
    - interval: 15s
       port: 3000
       path: /offsets/v1
```
