### PR TITLE
deprecate archived helm chart repo for SEO 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Run Kpow for Apache Kafka in Kubernetes
+# Archived: Kpow Helm Charts (Legacy)
 
-This repository has been archived.
+This repository has been archived and is no longer maintained.
 
-Helm charts have moved from `https://charts.kpow.io` to `https://charts.factorhouse.io`.
+**The official and actively maintained Helm charts for Kpow are now hosted at:**
+https://charts.factorhouse.io/charts/kpow/
 
 See [factorhouse/helm-charts](https://github.com/factorhouse/helm-charts) for our up-to-date product Helm Charts.
+
+This repository remains available only for existing users who still depend on https://charts.kpow.io.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository has been archived and is no longer maintained.
 
-**The official and actively maintained Helm charts for Kpow are now hosted at:**
+**The official and actively maintained Helm Charts for Kpow are now hosted at:**
 https://charts.factorhouse.io/charts/kpow/
 
 See [factorhouse/helm-charts](https://github.com/factorhouse/helm-charts) for our up-to-date product Helm Charts.

--- a/charts/kpow/README.md
+++ b/charts/kpow/README.md
@@ -1,15 +1,15 @@
-# Deprecated: Kpow Helm chart repository (legacy)
+# Deprecated: Kpow Helm Chart repository (legacy)
 
-This Helm chart repository is deprecated and no longer recommended for new installations.
+This Helm Chart repository is deprecated and no longer recommended for new installations.
 
-The official and actively maintained Helm charts for Kpow are now hosted at:
+The official and actively maintained Helm Charts for Kpow are now hosted at:
 
 - https://charts.factorhouse.io/charts/kpow/
 - https://github.com/factorhouse/helm-charts/tree/main/charts/kpow
 
-Some existing Kpow deployments reference https://charts.kpow.io. To avoid breaking those deployments, this chart repository remains accessible.
+Some existing Kpow deployments reference https://charts.kpow.io. To avoid breaking those deployments, this Helm Chart repository remains accessible.
 
-For all new deployments and upgrades, use the charts hosted at https://charts.factorhouse.io instead.
+For all new deployments and upgrades, use the Charts hosted at https://charts.factorhouse.io instead.
 
 ---
 
@@ -17,13 +17,13 @@ For all new deployments and upgrades, use the charts hosted at https://charts.fa
 
 [Kpow](https://kpow.io) is the all-in-one toolkit to manage, monitor, and learn about your Kafka resources.
 
-This Helm chart uses the [factorhouse/kpow](https://hub.docker.com/r/factorhouse/kpow) container from Dockerhub.
+This Helm Chart uses the [factorhouse/kpow](https://hub.docker.com/r/factorhouse/kpow) container from Dockerhub.
 
 # Helm Charts
 
-This repository contains a single Helm chart that uses the [factorhouse/kpow](https://hub.docker.com/r/factorhouse/kpow) container on Dockerhub.
+This repository contains a single Helm Chart that uses the [factorhouse/kpow](https://hub.docker.com/r/factorhouse/kpow) container on Dockerhub.
 
-> **Note:** For the latest supported Helm charts and documentation, see https://charts.factorhouse.io
+> **Note:** For the latest supported Helm Charts and documentation, see https://charts.factorhouse.io
 
 - [Prerequisites](#prerequisites)
 - [Kubernetes](#kubernetes)
@@ -245,7 +245,7 @@ data:
 kubectl apply -f ./kpow-secrets.yaml --namespace factorhouse
 ```
 
-Then run the helm chart (this can be used in conjunction with `envFromConfigMap`)
+Then run the Helm Chart (this can be used in conjunction with `envFromConfigMap`)
 
 See the Kubernetes documentation on [configuring all key value pairs in a secret as environment variables](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) for more information.
 

--- a/charts/kpow/README.md
+++ b/charts/kpow/README.md
@@ -1,4 +1,19 @@
-# Run Kpow for Apache Kafka in Kubernetes
+# Deprecated: Kpow Helm chart repository (legacy)
+
+This Helm chart repository is deprecated and no longer recommended for new installations.
+
+The official and actively maintained Helm charts for Kpow are now hosted at:
+
+- https://charts.factorhouse.io/charts/kpow/
+- https://github.com/factorhouse/helm-charts/tree/main/charts/kpow
+
+Some existing Kpow deployments reference https://charts.kpow.io. To avoid breaking those deployments, this chart repository remains accessible.
+
+For all new deployments and upgrades, use the charts hosted at https://charts.factorhouse.io instead.
+
+---
+
+# Run Kpow for Apache Kafka® in Kubernetes
 
 [Kpow](https://kpow.io) is the all-in-one toolkit to manage, monitor, and learn about your Kafka resources.
 
@@ -8,16 +23,18 @@ This Helm chart uses the [factorhouse/kpow](https://hub.docker.com/r/factorhouse
 
 This repository contains a single Helm chart that uses the [factorhouse/kpow](https://hub.docker.com/r/factorhouse/kpow) container on Dockerhub.
 
-* [Prerequisites](#prerequisites)
-* [Kubernetes](#kubernetes)
-* [Run Kpow in Kubernetes](#run-kpow-in-kubernetes)
-  * [Configure the Kpow Helm Repository](#configure-the-kpow-helm-repository)
-  * [Start a Kpow Instance](#start-a-kpow-instance)
-  * [Manage a Kpow Instance](#manage-a-kpow-instance)
-  * [Start Kpow with Local Changes](#start-kpow-with-local-changes)
-  * [Manage Sensitive Environment Variables](#manage-sensitive-environment-variables)
-  * [Provide Files to the Kpow Pod](#provide-files-to-the-kpow-pod)
-  * [Kpow Memory and CPU Requirements](#kpow-memory-and-cpu-requirements)
+> **Note:** For the latest supported Helm charts and documentation, see https://charts.factorhouse.io
+
+- [Prerequisites](#prerequisites)
+- [Kubernetes](#kubernetes)
+- [Run Kpow in Kubernetes](#run-kpow-in-kubernetes)
+  - [Configure the Kpow Helm Repository](#configure-the-kpow-helm-repository)
+  - [Start a Kpow Instance](#start-a-kpow-instance)
+  - [Manage a Kpow Instance](#manage-a-kpow-instance)
+  - [Start Kpow with Local Changes](#start-kpow-with-local-changes)
+  - [Manage Sensitive Environment Variables](#manage-sensitive-environment-variables)
+  - [Provide Files to the Kpow Pod](#provide-files-to-the-kpow-pod)
+  - [Kpow Memory and CPU Requirements](#kpow-memory-and-cpu-requirements)
 
 ## Prerequisites
 
@@ -68,20 +85,20 @@ helm repo update
 
 The minimum information required by Kpow to operate is:
 
-* License Details
-* Kafka Bootstrap URL
+- License Details
+- Kafka Bootstrap URL
 
 See the [Kpow Documentation](https://docs.kpow.io) for a full list of configuration options.
 
 #### Start Kpow with config from '--set env.XYZ'
 
-##### Quotation #####
+##### Quotation
 
 Some fields require quoting of characters within the value-string when using --set env.XXX to pass configuration.
 
 This particularly applies to commas, integers, and quotation marks (see examples below).
 
-##### Command #####
+##### Command
 
 Note, when using `--set` you may need to escape special characters with `\`, see:
 
@@ -162,7 +179,7 @@ Status:       Running
 #### View the Kpow Pod Logs
 
 ```bash
-kubectl logs --namespace factorhouse $POD_NAME 
+kubectl logs --namespace factorhouse $POD_NAME
 
 11:36:49.111 INFO  [main] kpow.system ? start Kpow
 ...
@@ -240,9 +257,9 @@ helm install --namespace factorhouse --create-namespace kpow ./kpow --set envFro
 
 There are occasions where you must provide files to the Kpow Pod in order for Kpow to run correctly, such files include:
 
-* RBAC configuration
-* SSL Keystores
-* SSL Truststores
+- RBAC configuration
+- SSL Keystores
+- SSL Truststores
 
 How you provide these files is down to user preference, we are not able to provide any support or instruction in this regard.
 


### PR DESCRIPTION
This repo is the first result on Google when you search "kpow helm charts". 

I've updated the root README as well as the Kpow chart README to clearly signal that it's legacy, without breaking for existing users. Ultimately we want to guide people (and search engines) to the charts.factorhouse.io location.

Adding "archived" and "deprecated" terms high in the rendered content *should* provide a clear signal to search engines to down rank this content. Including the canonical replacement `charts.factorhouse.io/charts/kpow/` should also help encourage better ranking for that location. 
